### PR TITLE
refactor: add environment prop to flags and improve flag guard for saveFlag

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.2.0",
     "@commitlint/config-conventional": "^17.2.0",
+    "@nestjs/class-validator": "^0.13.4",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@commitlint/cli': ^17.2.0
   '@commitlint/config-conventional': ^17.2.0
+  '@nestjs/class-validator': ^0.13.4
   '@nestjs/cli': ^9.0.0
   '@nestjs/common': ^9.0.0
   '@nestjs/config': ^2.2.0
@@ -54,6 +55,7 @@ dependencies:
 devDependencies:
   '@commitlint/cli': 17.2.0
   '@commitlint/config-conventional': 17.2.0
+  '@nestjs/class-validator': 0.13.4
   '@nestjs/cli': 9.1.5
   '@nestjs/schematics': 9.0.3_typescript@4.8.4
   '@nestjs/testing': 9.1.6_ymrbmmkpvmejpm3rdaw5glgevq
@@ -1766,6 +1768,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@nestjs/class-validator/0.13.4:
+    resolution: {integrity: sha512-/mqZL36LJ5uV5WDhi87Cd52IssuO+SStaOr2+6sBsvCCGUWkoJes4Wwzmm3m/gdHH+tsNxX60sVSzYcU6hAy9Q==}
+    dependencies:
+      libphonenumber-js: 1.10.14
+      validator: 13.7.0
     dev: true
 
   /@nestjs/cli/9.1.5:
@@ -5239,6 +5248,10 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /libphonenumber-js/1.10.14:
+    resolution: {integrity: sha512-McGS7GV/WjJ2KjfOGhJU1oJn29RYeo7Q+RpANRbUNMQ9gj5XArpbjurSuyYPTejFwbaUojstQ4XyWCrAzGOUXw==}
+    dev: true
+
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
@@ -6991,6 +7004,11 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /validator/13.7.0:
+    resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==}
+    engines: {node: '>= 0.10'}
     dev: true
 
   /vary/1.1.2:

--- a/api/src/flags/flag.dts.ts
+++ b/api/src/flags/flag.dts.ts
@@ -1,9 +1,18 @@
-import { FlagType, FlagValueType } from './schemas/flag.schema';
+import { IsNotEmpty, IsIn } from '@nestjs/class-validator';
+import { FlagEnv, FlagType, FlagValueType } from './schemas/flag.schema';
 
 export default class FlagDto {
+  @IsNotEmpty()
   name!: string;
 
+  @IsNotEmpty()
+  @IsIn(['boolean', 'string', 'number'])
   type!: FlagType;
 
+  @IsNotEmpty()
   value!: FlagValueType;
+
+  @IsNotEmpty()
+  @IsIn(['staging', 'production'])
+  environment!: FlagEnv;
 }

--- a/api/src/flags/flag.guard.ts
+++ b/api/src/flags/flag.guard.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
+import FlagDto from './flag.dts';
 
 @Injectable()
 export default class FlagGuard implements CanActivate {
@@ -14,17 +15,14 @@ export default class FlagGuard implements CanActivate {
   ): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
     const { body } = request;
-    if (!FlagGuard.hasAllProps(body))
+
+    if (!FlagGuard.checkValueType(body))
       throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
 
     return true;
   }
 
-  static hasAllProps(obj: any): boolean {
-    return (
-      Object.hasOwnProperty.call(obj, 'name') &&
-      Object.hasOwnProperty.call(obj, 'value') &&
-      Object.hasOwnProperty.call(obj, 'type')
-    );
+  static checkValueType(obj: FlagDto): boolean {
+    return typeof obj.value === obj.type;
   }
 }

--- a/api/src/flags/flags.service.ts
+++ b/api/src/flags/flags.service.ts
@@ -14,10 +14,11 @@ class FlagsService {
   ) {}
 
   static formatFlags(flags: FlagDocument[]): FlagDto[] {
-    return flags.map(({ name, type, value }) => ({
+    return flags.map(({ name, type, value, environment }) => ({
       name,
       type,
       value,
+      environment,
     }));
   }
 

--- a/api/src/flags/schemas/flag.schema.ts
+++ b/api/src/flags/schemas/flag.schema.ts
@@ -1,21 +1,27 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
-export type FlagType = 'bool' | 'string' | 'number';
+export type FlagType = 'boolean' | 'string' | 'number';
 export type FlagValueType = string | number | boolean;
+export type FlagEnv = 'staging' | 'production';
 
 @Schema()
 export class Flag {
-  @Prop({ type: String, index: { unique: true } })
+  @Prop({ type: String })
   name!: string;
 
-  @Prop()
+  @Prop({ type: String })
   type!: FlagType;
 
   @Prop({ type: String || Number || Boolean })
   value!: FlagValueType;
+
+  @Prop({ type: String })
+  environment!: FlagEnv;
 }
 
 export type FlagDocument = Flag & Document;
 
 export const FlagSchema = SchemaFactory.createForClass(Flag);
+
+FlagSchema.index({ name: 1, environment: 1 }, { unique: true });


### PR DESCRIPTION
- Added `environment` so flags can be stored for specific environment
- Added using `name` and `environment` as [compound index](https://www.mongodb.com/docs/manual/core/index-compound/) for every entry.
- Improved controller guard by adding data validation.