### PR TITLE
Update Kit -> SvelteKit framework has Insufficient CSRF protection for CORS requests

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@playwright/test": "1.28.1",
     "@sveltejs/adapter-auto": "2.0.0",
-    "@sveltejs/kit": "1.15.1",
+    "@sveltejs/kit": "1.15.4",
     "@tsconfig/svelte": "3.0.0",
     "@typescript-eslint/eslint-plugin": "5.45.0",
     "@typescript-eslint/parser": "5.45.0",


### PR DESCRIPTION
fixes security alert [#5](https://github.com/funnls/feature-flag/security/dependabot/5)