### PR TITLE
refactor: add a basic layout to display fetched flags

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,1 @@
+PUBLIC_API_URL=http://localhost

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scribr",
+  "name": "web",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/web/src/ambient.d.ts
+++ b/web/src/ambient.d.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars */
+declare type ThemeVariant = 'primary' | 'secondary';
+
+declare type FlagType = 'boolean' | 'string' | 'number';
+declare type FlagValueType = boolean | string | number;
+declare type FlagEnv = 'staging' | 'production';
+
+declare type FlagDataType = {
+  name: string;
+  type: FlagType;
+  value: FlagValueType;
+  environment: FlagEnv;
+};

--- a/web/src/lib/Button/Button.svelte
+++ b/web/src/lib/Button/Button.svelte
@@ -1,0 +1,21 @@
+<style>
+  button {
+    font-size: 16px;
+    padding: 0 6px 4px;
+    border: 0;
+  }
+
+  .primary {
+    border-bottom: 1px solid var(--BANANA_500);
+  }
+  .secondary {
+    border-bottom: 1px solid var(--STRAWBERRY_500);
+  }
+</style>
+
+<script lang="ts">
+  export let onClick: svelte.JSX.MouseEventHandler<HTMLButtonElement>;
+  export let buttonTheme: ThemeVariant = 'primary';
+</script>
+
+<button on:click="{onClick}" class="{buttonTheme}"><slot /></button>

--- a/web/src/lib/Flags/Flag.svelte
+++ b/web/src/lib/Flags/Flag.svelte
@@ -1,0 +1,30 @@
+<style>
+  .wrapper {
+    display: flex;
+    justify-content: space-between;
+    padding: 14px 10px;
+    border-bottom: 1px solid var(--SLATE_100);
+  }
+
+  .section {
+    width: 18%;
+  }
+</style>
+
+<script lang="ts">
+  import Button from '$lib/Button/Button.svelte';
+  export let flag: FlagDataType;
+</script>
+
+<div class="wrapper">
+  <div class="section">{flag.name}</div>
+  <div class="section">{flag.type}</div>
+  <div class="section">{flag.value}</div>
+  <div class="section">{flag.environment}</div>
+  <div class="section">
+    <Button onClick="{() => console.log('Disable button')}">Disable</Button>
+    <Button onClick="{() => console.log('Remove button')}" buttonTheme="secondary"
+      >Remove</Button
+    >
+  </div>
+</div>

--- a/web/src/lib/Flags/Flags.svelte
+++ b/web/src/lib/Flags/Flags.svelte
@@ -1,0 +1,61 @@
+<style>
+  .wrapper {
+    padding: 14px 10px;
+  }
+
+  .section_header {
+    display: flex;
+    border-bottom: 1px solid var(--MINT_900);
+    justify-content: space-between;
+    padding: 14px 10px;
+  }
+
+  .section {
+    width: 18%;
+  }
+</style>
+
+<script lang="ts">
+  import Flag from './Flag.svelte';
+  import { onMount } from 'svelte';
+  import { env } from '$env/dynamic/public';
+
+  let flags: FlagDataType[] = [];
+  let stagingFlags: FlagDataType[] = [];
+  let productionFlags: FlagDataType[] = [];
+
+  onMount(async () => {
+    try {
+      const res = await fetch(`${env.PUBLIC_API_URL}:3000/flags/getflags`);
+      flags = await res.json();
+
+      flags.forEach(flag => {
+        if (flag.environment === 'staging') {
+          stagingFlags.push(flag);
+        } else {
+          productionFlags.push(flag);
+        }
+      });
+    } catch (e) {
+      console.error({ e });
+    }
+    stagingFlags = stagingFlags;
+    productionFlags = productionFlags;
+  });
+</script>
+
+<div class="wrapper">
+  <div class="section_header">
+    <span class="section">Name</span>
+    <span class="section">Type</span>
+    <span class="section">Value</span>
+    <span class="section">Environment</span>
+    <span class="section">State</span>
+  </div>
+  {#each stagingFlags as flag}
+    <Flag flag="{flag}" />
+  {/each}
+  {#each productionFlags as flag}
+    <Flag flag="{flag}" />
+  {/each}
+</div>

--- a/web/src/lib/Selector/Selector.svelte
+++ b/web/src/lib/Selector/Selector.svelte
@@ -1,0 +1,18 @@
+<style>
+  div {
+    padding: 14px 10px;
+    border-bottom: 1px solid var(--GRAPE_700);
+  }
+</style>
+
+<script>
+  import Button from '$lib/Button/Button.svelte';
+</script>
+
+<div>
+  <Button onClick="{() => console.log('All button')}">All</Button>
+  <Button onClick="{() => console.log('Staging button')}">Staging</Button>
+  <Button onClick="{() => console.log('Production button')}" buttonTheme="secondary"
+    >Production</Button
+  >
+</div>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,12 @@
+<style>
+</style>
+
+<script lang="ts">
+  import Selector from '$lib/Selector/Selector.svelte';
+  import Flags from '$lib/Flags/Flags.svelte';
+</script>
+
 <main>
-  <h1>Welcome to SvelteKit</h1>
-  <p>
-    Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation
-  </p>
+  <Selector />
+  <Flags />
 </main>

--- a/web/static/global.css
+++ b/web/static/global.css
@@ -1,17 +1,15 @@
+@import './sweet.css';
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-}
-
-body {
-  background-color: black;
-  color: white;
   font-family: 'IBM Plex Mono';
+  background-color: var(--theme_bg_color);
+  color: var(--text_color);
 }
 
 main {
   width: 80%;
   margin: 0 auto;
-  background-color: red;
 }

--- a/web/static/sweet.css
+++ b/web/static/sweet.css
@@ -1,0 +1,116 @@
+:root {
+  /* widget text/foreground color */
+  --theme_fg_color: #c3c7d1;
+  /* text color for entries, views and content in general */
+  --theme_text_color: #c3c7d1;
+  /* widget base background color */
+  --theme_bg_color: #161925;
+  /* text widgets and the like base background color */
+  --theme_base_color: #181b28;
+  /* base background color of selections */
+  --theme_selected_bg_color: #00d3a7;
+  /* text/foreground color of selections */
+  --theme_selected_fg_color: #fefefe;
+  /* base background color of disabled widgets */
+  --insensitive_bg_color: #171a26;
+  /* text foreground color of disabled widgets */
+  --insensitive_fg_color: #6d707b;
+  /* disabled text widgets and the like base background color */
+  --insensitive_base_color: #181b28;
+  /* widget text/foreground color on backdrop windows */
+  --theme_unfocused_fg_color: #6d707b;
+  /* text color for entries, views and content in general on backdrop windows */
+  --theme_unfocused_text_color: #c3c7d1;
+  /* widget base background color on backdrop windows */
+  --theme_unfocused_bg_color: #161925;
+  /* text widgets and the like base background color on backdrop windows */
+  --theme_unfocused_base_color: #1a1d2b;
+  /* base background color of selections on backdrop windows */
+  --theme_unfocused_selected_bg_color: #00d3a7;
+  /* text/foreground color of selections on backdrop windows */
+  --theme_unfocused_selected_fg_color: #fefefe;
+  /* widgets main borders color */
+  --borders: rgba(238, 238, 238, 0.1);
+  /* widgets main borders color on backdrop windows */
+  --unfocused_borders: rgba(91, 93, 102, 0.19);
+
+  --text_color: #c3c7d1;
+
+  /* ---------------- */
+  --wm_unfocused_title: #6d707b;
+  --wm_highlight: rgba(0, 0, 0, 0);
+  --wm_borders_edge: rgba(255, 255, 255, 0.1);
+  --wm_bg_a: shade(#161925, 1.2);
+  --wm_bg_b: #161925;
+  --wm_shadow: alpha(black, 0.35);
+  --wm_border: alpha(black, 0.18);
+  --wm_button_hover_color_a: shade(#161925, 1.3);
+  --wm_button_hover_color_b: #161925;
+  --wm_button_active_color_a: shade(#161925, 0.85);
+  --wm_button_active_color_b: shade(#161925, 0.89);
+  --wm_button_active_color_c: shade(#161925, 0.9);
+  --content_view_bg: #181b28;
+  --text_view_bg: #181b28;
+  --budgie_tasklist_indicator_color: #00d3a7;
+  --budgie_tasklist_indicator_color_active: #00d3a7;
+  --STRAWBERRY_100: #ff8c82;
+  --STRAWBERRY_300: #ed5353;
+  --STRAWBERRY_500: #c6262e;
+  --STRAWBERRY_700: #a10705;
+  --STRAWBERRY_900: #7a0000;
+  --ORANGE_100: #ffc27d;
+  --ORANGE_300: #ffa154;
+  --ORANGE_500: #f37329;
+  --ORANGE_700: #cc3b02;
+  --ORANGE_900: #a62100;
+  --BANANA_100: #fff394;
+  --BANANA_300: #ffe16b;
+  --BANANA_500: #f9c440;
+  --BANANA_700: #d48e15;
+  --BANANA_900: #ad5f00;
+  --LIME_100: #d1ff82;
+  --LIME_300: #9bdb4d;
+  --LIME_500: #68b723;
+  --LIME_700: #3a9104;
+  --LIME_900: #206b00;
+  --MINT_100: #89ffdd;
+  --MINT_300: #43d6b5;
+  --MINT_500: #28bca3;
+  --MINT_700: #0e9a83;
+  --MINT_900: #007367;
+  --BLUEBERRY_100: #8cd5ff;
+  --BLUEBERRY_300: #64baff;
+  --BLUEBERRY_500: #3689e6;
+  --BLUEBERRY_700: #0d52bf;
+  --BLUEBERRY_900: #002e99;
+  --BUBBLEGUM_100: #fe9ab8;
+  --BUBBLEGUM_300: #f4679d;
+  --BUBBLEGUM_500: #de3e80;
+  --BUBBLEGUM_700: #bc245d;
+  --BUBBLEGUM_900: #910e38;
+  --GRAPE_100: #e4c6fa;
+  --GRAPE_300: #cd9ef7;
+  --GRAPE_500: #a56de2;
+  --GRAPE_700: #7239b3;
+  --GRAPE_900: #452981;
+  --COCOA_100: #a3907c;
+  --COCOA_300: #8a715e;
+  --COCOA_500: #715344;
+  --COCOA_700: #57392d;
+  --COCOA_900: #3d211b;
+  --SILVER_100: #fafafa;
+  --SILVER_300: #d4d4d4;
+  --SILVER_500: #abacae;
+  --SILVER_700: #7e8087;
+  --SILVER_900: #555761;
+  --SLATE_100: #95a3ab;
+  --SLATE_300: #667885;
+  --SLATE_500: #485a6c;
+  --SLATE_700: #273445;
+  --SLATE_900: #0e141f;
+  --BLACK_100: #666;
+  --BLACK_300: #4d4d4d;
+  --BLACK_500: #333;
+  --BLACK_700: #1a1a1a;
+  --BLACK_900: #000;
+}


### PR DESCRIPTION
Closes #8

This adds a basic layout to display flags fetched from the api.

A basic way to test this is to run the back end with

```sh
docker-compose --env-file env.production up --build
```

and once it's running, store some flags (using postman, insomnia...).

Then run the front-end (make sure to create a .env file from .env.example) and load the main page.
