### PR TITLE
feat(web): add enable/disable functionality

### DIFF
--- a/web/src/ambient.d.ts
+++ b/web/src/ambient.d.ts
@@ -6,8 +6,10 @@ declare type FlagValueType = boolean | string | number;
 declare type FlagEnv = 'staging' | 'production';
 
 declare type FlagDataType = {
+  id: string;
   name: string;
   type: FlagType;
   value: FlagValueType;
   environment: FlagEnv;
+  isEnabled: boolean;
 };

--- a/web/src/lib/Flags/Flag.svelte
+++ b/web/src/lib/Flags/Flag.svelte
@@ -9,11 +9,44 @@
   .section {
     width: 18%;
   }
+
+  .button-wrapper {
+    display: flex;
+    justify-content: space-between;
+  }
 </style>
 
 <script lang="ts">
+  import { env } from '$env/dynamic/public';
   import Button from '$lib/Button/Button.svelte';
   export let flag: FlagDataType;
+
+  const handleClick = async () => {
+    try {
+      const res = await fetch(`${env.PUBLIC_API_URL}:3000/flags/setEnabled`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          id: flag.id,
+          isEnabled: !flag.isEnabled
+        }),
+        headers: {
+          'Content-type': 'application/json; charset=UTF-8'
+        }
+      });
+
+      const { _id, isEnabled } = await res.json();
+
+      if (res.status === 200) {
+        flag = {
+          ...flag,
+          id: _id,
+          isEnabled
+        };
+      }
+    } catch (e) {
+      console.error({ e });
+    }
+  };
 </script>
 
 <div class="wrapper">
@@ -21,8 +54,8 @@
   <div class="section">{flag.type}</div>
   <div class="section">{flag.value}</div>
   <div class="section">{flag.environment}</div>
-  <div class="section">
-    <Button onClick="{() => console.log('Disable button')}">Disable</Button>
+  <div class="section button-wrapper">
+    <Button onClick="{handleClick}">{flag.isEnabled ? 'Disable' : 'Enable'}</Button>
     <Button onClick="{() => console.log('Remove button')}" buttonTheme="secondary"
       >Remove</Button
     >

--- a/web/src/lib/Flags/Flags.svelte
+++ b/web/src/lib/Flags/Flags.svelte
@@ -16,18 +16,19 @@
 </style>
 
 <script lang="ts">
-  import Flag from './Flag.svelte';
-  import { onMount } from 'svelte';
   import { env } from '$env/dynamic/public';
+  import { onMount } from 'svelte';
+  import Flag from './Flag.svelte';
 
-  let flags: FlagDataType[] = [];
   let stagingFlags: FlagDataType[] = [];
   let productionFlags: FlagDataType[] = [];
+
+  const sectionHeaders = ['Name', 'Type', 'Value', 'Environment', 'State'];
 
   onMount(async () => {
     try {
       const res = await fetch(`${env.PUBLIC_API_URL}:3000/flags/getflags`);
-      flags = await res.json();
+      const flags: FlagDataType[] = await res.json();
 
       flags.forEach(flag => {
         if (flag.environment === 'staging') {
@@ -36,26 +37,24 @@
           productionFlags.push(flag);
         }
       });
+      stagingFlags = stagingFlags;
+      productionFlags = productionFlags;
     } catch (e) {
       console.error({ e });
     }
-    stagingFlags = stagingFlags;
-    productionFlags = productionFlags;
   });
 </script>
 
 <div class="wrapper">
   <div class="section_header">
-    <span class="section">Name</span>
-    <span class="section">Type</span>
-    <span class="section">Value</span>
-    <span class="section">Environment</span>
-    <span class="section">State</span>
+    {#each sectionHeaders as section}
+      <span class="section">{section}</span>
+    {/each}
   </div>
-  {#each stagingFlags as flag}
+  {#each stagingFlags as flag (flag.id)}
     <Flag flag="{flag}" />
   {/each}
-  {#each productionFlags as flag}
+  {#each productionFlags as flag (flag.id)}
     <Flag flag="{flag}" />
   {/each}
 </div>


### PR DESCRIPTION
This adds functionality to the `enable/disable` button using recent changes to the api.

**Test**
- Run the api and store some flags
- Run the frontend
- Click on the `enable/disable` button and make sure that after clicking the row displays the real state of the flag

